### PR TITLE
GitHub Actions で CI を動かします

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: test_and_build 
+
+on: [push]
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: setup
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
+          cache: true
+
+      - name: インストール
+        run: make dev-deps
+
+      - name: テスト
+        run: make test
+
+      - name: ビルド
+        # cli がビルドできることを確認する
+        run: make cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       - name: インストール
         run: make dev-deps
 
+      - name: 静的チェック
+        run: make check
+
       - name: テスト
         run: make test
 

--- a/infrastructure/database/diary/retrieve_diary.go
+++ b/infrastructure/database/diary/retrieve_diary.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/kaikourok/lunchtote-backend/entity/model"
-	diaryModel "github.com/kaikourok/lunchtote-backend/entity/model"
 )
 
 func (db *DiaryRepository) RetrieveDiary(characterId *int, targetId, nth int) (*model.Diary, error) {
@@ -49,7 +48,7 @@ func (db *DiaryRepository) RetrieveDiary(characterId *int, targetId, nth int) (*
 			diaries.character = $1 AND diaries.nth = $2;
 	`, targetId, nth)
 
-	var diary diaryModel.Diary
+	var diary model.Diary
 	err := row.Scan(
 		&diary.Author.Id,
 		&diary.Author.Name,

--- a/makefile
+++ b/makefile
@@ -31,6 +31,11 @@ gen-buf:
 test:
 	go test -v ./...
 
+.PHONY: check
+check:
+	go vet ./...
+	staticcheck ./...
+
 .PHONY: init
 init:
 	make cli


### PR DESCRIPTION
# CI の導入をします

- 依存モジュールのインストール
- テスト
- 静的チェック
- ビルド

が正常に動作することを GitHub Actions でチェックします。
静的チェックは Go 組み込みの go vet と makefile 内でインストールしている staticcheck を実行します。
簡便のため `make check` でまとめて実行できるように変更を加えます。

# 他

staticcheck を実際に行うと `infrastructure/database/diary/retrieve_diary.go:6:2: package "github.com/kaikourok/lunchtote-backend/entity/model" is being imported more than once (ST1019)` という警告が出ます。
この警告は同じファイル内で同じモジュールを 2 度インポートしているために出る警告です。

`"github.com/kaikourok/lunchtote-backend/entity/model"`
`diaryModel "github.com/kaikourok/lunchtote-backend/entity/model"`

の 2 つがあるので、後者を使っている方を単に `model` に変更します。

# 例

https://github.com/yuitest/lunchtote-backend/actions/runs/3749291465/jobs/6367606547
にて実際にこの PR に対して GitHub Actions が動作した結果をみることができます。

<img width="1345" alt="Screenshot 2022-12-21 at 21 47 52" src="https://user-images.githubusercontent.com/726855/208908994-4cfa8c7a-50f7-4aac-8229-624a4e762cc8.png">

