### PR TITLE
CIで使用するGo言語のバージョンを1.20に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.20'
           cache: true
 
       - name: インストール


### PR DESCRIPTION
ひとまず作成。
まだ1.20は出たばかりで不安定（staticcheckがうまく動作していない？）なようなので頃合いを見てマージ。