### PR TITLE
fix: 新規メンバー参加通知データを作成する前にlengthをチェックする

### DIFF
--- a/infrastructure/database/room/join_to_room.go
+++ b/infrastructure/database/room/join_to_room.go
@@ -131,19 +131,21 @@ func (db *RoomRepository) JoinToRoom(targetId, roomId int) (room *model.RoomOver
 			inserters = append(inserters, inserter)
 		}
 
-		_, err = tx.NamedExec(`
-			INSERT INTO notifications_new_member_data (
-				notification,
-				room,
-				character
-			) VALUES (
-				:notification_id,
-				:room_id,
-				:character_id
-			)
-		`, inserters)
-		if err != nil {
-			return err
+		if 0 < len(inserters) {
+			_, err = tx.NamedExec(`
+				INSERT INTO notifications_new_member_data (
+					notification,
+					room,
+					character
+				) VALUES (
+					:notification_id,
+					:room_id,
+					:character_id
+				)
+			`, inserters)
+			if err != nil {
+				return err
+			}
 		}
 
 		_, err = tx.Exec(`


### PR DESCRIPTION
# 現象
ルームへの参加時に新規メンバー参加通知を送る相手がいない場合、insertersがlen: 0になるため、Insert文実行時にlength of array is 0エラーとなる。

# スタックトレース

```
{"level":"error","ts":1676734400.59211,"caller":"logger/logger.go:28","msg":"[length of array is 0: []room.newMemberNotificationInserter{}]","stacktrace":"github.com/kaikourok/lunchtote-backend/infrastructure/logger.(*Logger).Error\n\t/app/infrastructure/logger/logger.go:28\ngithub.com/kaikourok/lunchtote-backend/usecase/room.(*RoomUsecase).PostRoomMessage\n\t/app/usecase/room/post_room_message.go:54\ngithub.com/kaikourok/lunchtote-backend/cmd/server/controller/room.(*RoomController).PostRoomMessage\n\t/app/cmd/server/controller/room/post_room_message.go:20\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.8.1/context.go:173\ngithub.com/kaikourok/lunchtote-backend/cmd/server/middleware.Auth.func1\n\t/app/cmd/server/middleware/authentication.go:22\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.8.1/context.go:173\ngithub.com/gin-contrib/sessions.Sessions.func1\n\t/go/pkg/mod/github.com/gin-contrib/sessions@v0.0.5/sessions.go:54\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.8.1/context.go:173\nmain.NewRouter.func1\n\t/app/cmd/server/router.go:42\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.8.1/context.go:173\ngithub.com/gin-gonic/gin.CustomRecoveryWithWriter.func1\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.8.1/recovery.go:101\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.8.1/context.go:173\ngithub.com/gin-gonic/gin.LoggerWithConfig.func1\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.8.1/logger.go:240\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.8.1/context.go:173\ngithub.com/gin-gonic/gin.(*Engine).handleHTTPRequest\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.8.1/gin.go:616\ngithub.com/gin-gonic/gin.(*Engine).ServeHTTP\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.8.1/gin.go:572\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2936\nnet/http.(*conn).serve\n\t/usr/local/go/src/net/http/server.go:1995"}
```

# 対応
条件分岐追加