### PR TITLE
fix: ルーム権限のうち、所属ルーム作成権限のみ常にnullでフロントへ返される

### DIFF
--- a/infrastructure/database/room/retrieve_room_role_settings.go
+++ b/infrastructure/database/room/retrieve_room_role_settings.go
@@ -17,6 +17,7 @@ func (db *RoomRepository) RetrieveRoomRoleSettings(roomId int) (roles []model.Ro
 			rooms_roles.use_reply,
 			rooms_roles.use_secret,
 			rooms_roles.delete_other_message,
+			rooms_roles.create_children_room,
 			rooms_roles.type
 		FROM
 			rooms
@@ -46,6 +47,7 @@ func (db *RoomRepository) RetrieveRoomRoleSettings(roomId int) (roles []model.Ro
 			&role.UseReply,
 			&role.UseSecret,
 			&role.DeleteOtherMessage,
+			&role.CreateChildrenRoom,
 			&role.Type,
 		)
 		if err != nil {


### PR DESCRIPTION
# 現象
ルームの権限設定で、ルーム作成権限をあり、またはなしに変更して更新しても、ブラウザをリロードすると「-」で表示される。
APIのレスポンスではあり/なしどちらでもnullが返されている。

# 対応
SQLでも取得していなかったので追加。
